### PR TITLE
EvidenceLevel

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
@@ -172,27 +172,23 @@ public class Evidence implements java.io.Serializable {
         }
         return true;
     }
-
-    public Evidence CloneEvidence(){
-            Evidence another = new Evidence();
-            another.evidenceId = this.getEvidenceId();
-            another.evidenceType = this.getEvidenceType();
-            another.tumorType = this.getTumorType();
-            another.gene = this.getGene();
-            another.alterations = this.getAlterations();
-            another.shortDescription = this.getShortDescription();
-            another.description = this.getDescription();
-            another.treatments = this.getTreatments();
-            another.knownEffect = this.getKnownEffect();
-            another.status = this.getStatus();
-            another.lastEdit = this.getLastEdit();
-            another.levelOfEvidence = this.getLevelOfEvidence();
-            another.articles = this.getArticles();
-            another.nccnGuidelines = this.getNccnGuidelines();
-            another.clinicalTrials = this.getClinicalTrials();
-
-            return another;
-        }
+    public Evidence(Evidence e){
+            evidenceId = e.evidenceId;
+            evidenceType = e.evidenceType;
+            tumorType = e.tumorType;
+            gene = e.gene;
+            alterations = e.alterations;
+            shortDescription = e.shortDescription;
+            description = e.description;
+            treatments = e.treatments;
+            knownEffect = e.knownEffect;
+            status = e.status;
+            lastEdit = e.lastEdit;
+            levelOfEvidence = e.levelOfEvidence;
+            articles = e.articles;
+            nccnGuidelines = e.nccnGuidelines;
+            clinicalTrials = e.clinicalTrials;
+    }
     
 }
 

--- a/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
+++ b/core/src/main/java/org/mskcc/cbio/oncokb/model/Evidence.java
@@ -173,7 +173,27 @@ public class Evidence implements java.io.Serializable {
         return true;
     }
 
+    public Evidence CloneEvidence(){
+            Evidence another = new Evidence();
+            another.evidenceId = this.getEvidenceId();
+            another.evidenceType = this.getEvidenceType();
+            another.tumorType = this.getTumorType();
+            another.gene = this.getGene();
+            another.alterations = this.getAlterations();
+            another.shortDescription = this.getShortDescription();
+            another.description = this.getDescription();
+            another.treatments = this.getTreatments();
+            another.knownEffect = this.getKnownEffect();
+            another.status = this.getStatus();
+            another.lastEdit = this.getLastEdit();
+            another.levelOfEvidence = this.getLevelOfEvidence();
+            another.articles = this.getArticles();
+            another.nccnGuidelines = this.getNccnGuidelines();
+            another.clinicalTrials = this.getClinicalTrials();
 
+            return another;
+        }
+    
 }
 
 

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
@@ -287,8 +287,9 @@ public class EvidenceController {
                                     filtered.add(evidence);
                                 } else {
                                     if (evidence.getLevelOfEvidence() != null && evidence.getLevelOfEvidence().equals(LevelOfEvidence.LEVEL_1)) {
-                                        evidence.setLevelOfEvidence(LevelOfEvidence.LEVEL_2B);
-                                        filtered.add(evidence);
+                                        Evidence tempEvidence = evidence.CloneEvidence();
+                                        tempEvidence.setLevelOfEvidence(LevelOfEvidence.LEVEL_2B);
+                                        filtered.add(tempEvidence);
                                     }
                                 }
                             }

--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
@@ -287,7 +287,7 @@ public class EvidenceController {
                                     filtered.add(evidence);
                                 } else {
                                     if (evidence.getLevelOfEvidence() != null && evidence.getLevelOfEvidence().equals(LevelOfEvidence.LEVEL_1)) {
-                                        Evidence tempEvidence = evidence.CloneEvidence();
+                                        Evidence tempEvidence = new Evidence(evidence);
                                         tempEvidence.setLevelOfEvidence(LevelOfEvidence.LEVEL_2B);
                                         filtered.add(tempEvidence);
                                     }


### PR DESCRIPTION
bug: return wrong evidence level result when multiple cancer types are
chosen for some mutations

bug cause:
call setLevelOfEvidence function changed original evidence data

bug fix:
clone original evidence item and make change to the copy