### PR TITLE
Issue #54 annotation missing for braf BRAF-KIAA1549 fusion

### DIFF
--- a/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
+++ b/web/src/main/java/org/mskcc/cbio/oncokb/controller/EvidenceController.java
@@ -208,13 +208,9 @@ public class EvidenceController {
                 //Consequence format  a, b+c, d ... each variant pair (gene + alteration) could have one or multiple consequences. Multiple consequences are separated by '+'
                 for (String con : consequence.split("\\+")) {
                     Alteration alt = new Alteration();
-                    if (con.toLowerCase().contains("fusion")) {
-                        alt.setAlteration("fusions");
-                    } else {
-                        alt.setAlteration(alteration);
-                        variantConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm(con);
-                        alt.setConsequence(variantConsequence);
-                    }
+                    alt.setAlteration(alteration);
+                    variantConsequence = VariantConsequenceUtils.findVariantConsequenceByTerm(con);
+                    alt.setConsequence(variantConsequence);
                     alt.setAlterationType(AlterationType.MUTATION);
                     alt.setGene(gene);
 


### PR DESCRIPTION
bug: annotation info is missing for some mutations. for example for the query below, only GENE_SUMMARY and GENE_BACKGROUND evidence got returned
{
    "geneStatus": "Complete", 
    "source": "cbioportal", 
    "evidenceTypes": "GENE_SUMMARY,GENE_BACKGROUND,ONCOGENIC,MUTATION_EFFECT,VUS,STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_SENSITIVITY,STANDARD_THERAPEUTIC_IMPLICATIONS_FOR_DRUG_RESISTANCE", 
    "queries": [
        
        {
            "hugoSymbol": "BRAF", 
            "alteration": "BRAF-KIAA1549 fusion", 
            "tumorType": "Glioma", 
            "consequence": "fusion", 
            "id": "6342993"
        }
    ]
}

note: Right now, remove the consequence fusion condition check helps to return other evidence type info, but might need to do more test to ensure this is the problem.